### PR TITLE
Make Github oauth configuration optional, useful for throwaway clusters

### DIFF
--- a/hosted-cluster/templates/github-oauth-idp-secret.yaml
+++ b/hosted-cluster/templates/github-oauth-idp-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.github }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,3 +8,4 @@ type: Opaque
 stringData:
   "clientID": {{ .Values.github.clientID }}
   "clientSecret": {{ .Values.github.clientSecret }}
+{{ end }}

--- a/hosted-cluster/templates/hostedcluster.yaml
+++ b/hosted-cluster/templates/hostedcluster.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   autoscaling: {}
   configuration:
-    {{- if not (eq .Values.github.clientID "") }}
+    {{- if .Values.github }}
     oauth:
       identityProviders:
       - github:

--- a/hosted-cluster/values.yaml
+++ b/hosted-cluster/values.yaml
@@ -41,10 +41,10 @@ vault:
   roleID: ""
   secretID: ""
 
-github:
-  clientID: ""
-  clientSecret: ""
-  teams: []
+# github:
+#   clientID: ""
+#   clientSecret: ""
+#   teams: []
 
 managedClusterSet: ""
 managedClusterExtraLabels: []

--- a/variables.tf
+++ b/variables.tf
@@ -64,6 +64,14 @@ variable "fips_enabled" {
   type    = bool
   default = false
 }
+variable "github_oauth_enabled" {
+  type    = bool
+  default = true
+}
+variable "github_oauth_authorized_teams" {
+  type    = list(string)
+  default = ["3scale/operations"]
+}
 variable "oauth_endpoint_certificate_secret" {
   type    = string
   default = ""

--- a/vault.tf
+++ b/vault.tf
@@ -24,6 +24,7 @@ resource "vault_approle_auth_backend_role_secret_id" "this" {
 
 # Retrieve GitHub oauth credentials from vault
 module "github_oauth_idp" {
+  count  = var.github_oauth_enabled ? 1 : 0
   source = "git@github.com:3scale-ops/tf-vault-secret.git?ref=tags/0.1.3"
   path   = "kubernetes/${var.environment}-${var.project}/${var.cluster}/github-oauth-idp"
 }


### PR DESCRIPTION
After creating a throwaway cluster that will live just a few days I realised that being able to deploy a cluster without the GitHub oauth configured is useful (we can just provide admin user/pass) to reduce the effort required in these cases.
This PR makes the github oauth configuration optional.

Example of a cluster without oauth:

```hcl
module "hostedcluster" {
  source                = "/home/roi/github.com/3scale/tf-hypershift-hostedcluster"
  environment           = local.environment
  project               = local.project
  cluster               = local.cluster
  namespace             = "clusters"
  vpc_id                = data.terraform_remote_state.vpc.outputs.vpc_id
  subnet_ids            = [data.aws_subnet.selected_subnet.id]
  oidc_bucket_name      = data.terraform_remote_state.hypershift.outputs.s3_oidc_bucket_name
  consumer_domain       = data.terraform_remote_state.route53.outputs.dev3scanet_zonename
  provider_domain       = data.terraform_remote_state.hypershift.outputs.hcpdev3scanet_zonename
  release_image         = "quay.io/openshift-release-dev/ocp-release:${local.cluster_version}-multi-x86_64"
  fips_enabled          = false
  workers_instance_type = local.workers_type
  worker_replicas       = local.workers_count
  pull_secret           = "hypershift-pull-secret"
  ssh_key               = "hypershift-ssh-key"
  github_oauth_enabled  = false
  managedclusterset     = "hypershift"
}
```

/kind feature
/priority important-soon
/assign