### PR TITLE
Fix optional provider_domain param

### DIFF
--- a/hosted-cluster/templates/hostedcluster.yaml
+++ b/hosted-cluster/templates/hostedcluster.yaml
@@ -98,12 +98,10 @@ spec:
       {{- end }}
   - service: OAuthServer
     servicePublishingStrategy:
-      {{- if .Values.providerDomain }}
       type: Route
+      {{- if .Values.providerDomain }}
       route:
         hostname: "oauth-{{ .Values.name }}.{{ .Values.providerDomain }}"
-      {{- else }}
-      type: LoadBalancer
       {{- end }}
   - service: Konnectivity
     servicePublishingStrategy:

--- a/inputs.tf
+++ b/inputs.tf
@@ -23,5 +23,6 @@ data "aws_route53_zone" "consumer" {
 }
 
 data "aws_route53_zone" "provider" {
-  name = var.provider_domain
+  count = (var.provider_domain != "" ? 1 : 0)
+  name  = var.provider_domain
 }

--- a/variables.tf
+++ b/variables.tf
@@ -21,7 +21,8 @@ variable "oidc_bucket_name" {
   type = string
 }
 variable "provider_domain" {
-  type = string
+  type    = string
+  default = ""
 }
 
 variable "consumer_domain" {


### PR DESCRIPTION
The module failed if the `provider_domain` option was not set. This PR fixes it.

/kind bug
/priority important-longterm
/assign